### PR TITLE
Stop training when neural network return a NaN

### DIFF
--- a/src/neural_network/NeuralNetwork.cpp
+++ b/src/neural_network/NeuralNetwork.cpp
@@ -77,7 +77,7 @@ vector<float> NeuralNetwork::output(const vector<float>& inputs, bool temporalRe
         outputs = layers[l]->output(outputs, temporalReset);
     }
 
-    if (std::any_of(outputs.begin(), outputs.end(), [](const float& v) { return isnan(v); }))
+    if (std::any_of(outputs.begin(), outputs.end(), [](const float& v) { return !isnormal(v); }))
     {
         cout << "pouet pouet pouet pouet pouet pouet pouet" << endl;
         this->outputNan = true;

--- a/src/neural_network/NeuralNetwork.cpp
+++ b/src/neural_network/NeuralNetwork.cpp
@@ -77,11 +77,8 @@ vector<float> NeuralNetwork::output(const vector<float>& inputs, bool temporalRe
         outputs = layers[l]->output(outputs, temporalReset);
     }
 
-    if (std::any_of(outputs.begin(), outputs.end(), [](const float& v) { return !isnormal(v); }))
-    {
-        cout << "pouet pouet pouet pouet pouet pouet pouet" << endl;
+    if (std::any_of(outputs.begin(), outputs.end(), [](const float& v) { return !isnormal(v) && v != 0.0f; }))
         this->outputNan = true;
-    }
 
     return outputs;
 }

--- a/src/neural_network/NeuralNetwork.cpp
+++ b/src/neural_network/NeuralNetwork.cpp
@@ -77,10 +77,13 @@ vector<float> NeuralNetwork::output(const vector<float>& inputs, bool temporalRe
         outputs = layers[l]->output(outputs, temporalReset);
     }
 
+    if (std::any_of(outputs.begin(), outputs.end(), [](const float& v) { return isnan(v); }))
+        this->outputNan = true;
+
     return outputs;
 }
 
-std::vector<float> snn::internal::NeuralNetwork::outputForBackpropagation(const std::vector<float>& inputs, bool temporalReset)
+std::vector<float> NeuralNetwork::outputForBackpropagation(const std::vector<float>& inputs, bool temporalReset)
 {
     auto outputs = layers[0]->outputForBackpropagation(inputs, temporalReset);
 
@@ -97,6 +100,8 @@ void NeuralNetwork::backpropagationAlgorithm(const vector<float>& inputs, const 
                                              bool temporalReset)
 {
     const auto outputs = this->outputForBackpropagation(inputs, temporalReset);
+    if (this->outputNan)
+        return;
     auto errors = calculateError(outputs, desired);
 
     for (size_t l = this->layers.size() - 1; l > 0; --l)
@@ -107,19 +112,24 @@ void NeuralNetwork::backpropagationAlgorithm(const vector<float>& inputs, const 
 }
 
 inline
-vector<float>& NeuralNetwork::calculateError(const vector<float>& outputs, const vector<float>& desired) const
+vector<float> NeuralNetwork::calculateError(const vector<float>& outputs, const vector<float>& desired) const
 {
-    auto errors = new vector<float>(this->layers.back()->getNumberOfNeurons(), 0);
-    for (size_t n = 0; n < errors->size(); ++n)
+    vector<float> errors(this->layers.back()->getNumberOfNeurons(), 0);
+    for (size_t n = 0; n < errors.size(); ++n)
     {
         if (isnan(desired[n]))
-            (*errors)[n] = 0;
+            errors[n] = 0;
         else
         {
-            (*errors)[n] = 2 * (desired[n] - outputs[n]);
+            errors[n] = 2 * (desired[n] - outputs[n]);
         }
     }
-    return *errors;
+    return errors;
+}
+
+bool NeuralNetwork::hasNan() const
+{
+    return this->outputNan;
 }
 
 int NeuralNetwork::getNumberOfLayers() const
@@ -175,7 +185,7 @@ int NeuralNetwork::isValid() const
     for (const auto& layer : this->layers)
     {
         err = layer->isValid();
-        if(err != 0)
+        if (err != 0)
             return err;
     }
     return 0;

--- a/src/neural_network/NeuralNetwork.cpp
+++ b/src/neural_network/NeuralNetwork.cpp
@@ -78,7 +78,10 @@ vector<float> NeuralNetwork::output(const vector<float>& inputs, bool temporalRe
     }
 
     if (std::any_of(outputs.begin(), outputs.end(), [](const float& v) { return isnan(v); }))
+    {
+        cout << "pouet pouet pouet pouet pouet pouet pouet" << endl;
         this->outputNan = true;
+    }
 
     return outputs;
 }

--- a/src/neural_network/NeuralNetwork.hpp
+++ b/src/neural_network/NeuralNetwork.hpp
@@ -27,9 +27,12 @@ namespace snn::internal
         static bool isTheFirst; // TODO: remplace by seed
         static void initialize();
 
+        bool outputNan = false;
+
         void backpropagationAlgorithm(const std::vector<float>& inputs, const std::vector<float>& desired,
                                       bool temporalReset);
-        std::vector<float>& calculateError(const std::vector<float>& outputs, const std::vector<float>& desired) const;
+        std::vector<float> calculateError(const std::vector<float>& outputs, const std::vector<float>& desired) const;
+
 
         friend class boost::serialization::access;
         template <class Archive>
@@ -56,8 +59,9 @@ namespace snn::internal
         NeuralNetwork() = default; // use restricted to Boost library only
         NeuralNetwork(std::vector<LayerModel>& architecture, NeuralNetworkOptimizerModel optimizer);
         NeuralNetwork(const NeuralNetwork& neuralNetwork);
-        ~NeuralNetwork() = default;
-
+        virtual ~NeuralNetwork() = default;
+        
+        [[nodiscard]] bool hasNan() const;
         [[nodiscard]] int getNumberOfLayers() const;
         [[nodiscard]] int getNumberOfInputs() const;
         [[nodiscard]] int getNumberOfOutputs() const;

--- a/src/neural_network/StatisticAnalysis.cpp
+++ b/src/neural_network/StatisticAnalysis.cpp
@@ -10,6 +10,26 @@ void StatisticAnalysis::initialize(int numberOfCluster)
     this->startTesting();
 }
 
+void StatisticAnalysis::setResultsAsNan()
+{
+    for (auto& c : clusters)
+    {
+        c.truePositive = NAN;
+        c.trueNegative = NAN;
+        c.falsePositive = NAN;
+        c.falseNegative = NAN;
+        c.totalError = NAN;
+    }
+    numberOfDataWellClassified = NAN;
+    numberOfDataMisclassified = NAN;
+
+    this->globalClusteringRate = NAN;
+    this->weightedClusteringRate = NAN;
+    this->f1Score = NAN;
+    this->meanAbsoluteError = NAN;
+    this->rootMeanSquaredError = NAN;
+}
+
 void StatisticAnalysis::startTesting()
 {
     for (auto& c : clusters)

--- a/src/neural_network/StatisticAnalysis.hpp
+++ b/src/neural_network/StatisticAnalysis.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <limits>
 #include <vector>
 #include <boost/serialization/access.hpp>
 
@@ -50,12 +49,12 @@ namespace snn::internal
         float f1ScoreMax = -1.0f;
         float meanAbsoluteErrorMin = -1.0f;
         float rootMeanSquaredErrorMin = -1.0f;
-        
-        float computeGlobalClusteringRate() const;
-        float computeWeightedClusteringRate() const;
-        float computeF1Score() const;
-        float computeMeanAbsoluteError() const;
-        float computeRootMeanSquaredError() const;
+
+        [[nodiscard]] float computeGlobalClusteringRate() const;
+        [[nodiscard]] float computeWeightedClusteringRate() const;
+        [[nodiscard]] float computeF1Score() const;
+        [[nodiscard]] float computeMeanAbsoluteError() const;
+        [[nodiscard]] float computeRootMeanSquaredError() const;
 
     protected:
         StatisticAnalysis() = default;
@@ -63,6 +62,8 @@ namespace snn::internal
         virtual ~StatisticAnalysis() = default;
 
         void initialize(int numberOfCluster);
+
+        void setResultsAsNan();
 
         void evaluateOnceForRegression(const std::vector<float>& outputs, 
                                        const std::vector<float>& desiredOutputs,

--- a/src/neural_network/StraightforwardNeuralNetwork.hpp
+++ b/src/neural_network/StraightforwardNeuralNetwork.hpp
@@ -23,6 +23,8 @@ namespace snn
         int numberOfIteration = 0;
         int numberOfTrainingsBetweenTwoEvaluations = 0;
 
+        void resetTrainingValues();
+
         void train(Data& data);
         void evaluateOnce(Data& data);
 

--- a/src/neural_network/layer/neuron/activation_function/Sigmoid.hpp
+++ b/src/neural_network/layer/neuron/activation_function/Sigmoid.hpp
@@ -17,12 +17,12 @@ namespace snn::internal
 
         float function(const float x) const override
         {
-            return 1.0f / (1.0f + std::exp(-x));
+            return (tanhf(x / 2.0f) + 1.0f) / 2.0f;
         }
 
         float derivative(const float x) const override
         {
-            return std::exp(-x) / powf((std::exp(-x) + 1.0f), 2);
+            return (1 - powf(tanhf(x / 2), 2)) / 4;
         }
     };
 }

--- a/src/neural_network/layer/neuron/activation_function/Tanh.hpp
+++ b/src/neural_network/layer/neuron/activation_function/Tanh.hpp
@@ -17,12 +17,12 @@ namespace snn::internal
 
         float function(const float x) const override
         {
-            return std::tanh(x);
+            return tanhf(x);
         }
 
         float derivative(const float x) const override
         {
-            return 1 - powf(std::tanh(x), 2);
+            return 1 - powf(tanhf(x), 2);
         }
     };
 }

--- a/tests/dataset_tests/Iris/IrisTest.cpp
+++ b/tests/dataset_tests/Iris/IrisTest.cpp
@@ -67,8 +67,9 @@ TEST_F(IrisTest, correctlyNan)
     auto accuracy = neuralNetwork.getGlobalClusteringRate();
     auto score = neuralNetwork.getF1Score();
     auto mae = neuralNetwork.getMeanAbsoluteError();
-    ASSERT_TRUE(neuralNetwork.hasNan());
     ASSERT_TRUE(isnan(accuracy));
     ASSERT_TRUE(isnan(score));
     ASSERT_TRUE(isnan(mae));
+    ASSERT_TRUE(neuralNetwork.hasNan());
+    
 }

--- a/tests/dataset_tests/Iris/IrisTest.cpp
+++ b/tests/dataset_tests/Iris/IrisTest.cpp
@@ -52,3 +52,23 @@ TEST_F(IrisTest, trainNeuralNetwork)
     auto accuracy = neuralNetwork.getGlobalClusteringRateMax();
     ASSERT_ACCURACY(accuracy, 0.98f);
 }
+
+TEST_F(IrisTest, correctlyNan)
+{
+    StraightforwardNeuralNetwork neuralNetwork({
+        Input(4),
+        FullyConnected(25),
+        FullyConnected(3)
+    },
+        StochasticGradientDescent(0.99f, 0.99f));
+    neuralNetwork.startTraining(*data);
+    neuralNetwork.waitFor(2_s);
+    neuralNetwork.stopTraining();
+    auto accuracy = neuralNetwork.getGlobalClusteringRate();
+    auto score = neuralNetwork.getF1Score();
+    auto mae = neuralNetwork.getMeanAbsoluteError();
+    ASSERT_TRUE(neuralNetwork.hasNan());
+    ASSERT_TRUE(isnan(accuracy));
+    ASSERT_TRUE(isnan(score));
+    ASSERT_TRUE(isnan(mae));
+}

--- a/tests/dataset_tests/Iris/IrisTest.cpp
+++ b/tests/dataset_tests/Iris/IrisTest.cpp
@@ -62,14 +62,15 @@ TEST_F(IrisTest, correctlyNan)
     },
         StochasticGradientDescent(0.99f, 0.99f));
     neuralNetwork.startTraining(*data);
-    neuralNetwork.waitFor(2_s);
+    neuralNetwork.waitFor(10_s);
     neuralNetwork.stopTraining();
     auto accuracy = neuralNetwork.getGlobalClusteringRate();
     auto score = neuralNetwork.getF1Score();
     auto mae = neuralNetwork.getMeanAbsoluteError();
+    cout << "  accuracy = " << accuracy << endl;
+    cout << "  mae = " << mae << endl;
+    ASSERT_TRUE(neuralNetwork.hasNan());
     ASSERT_TRUE(isnan(accuracy));
     ASSERT_TRUE(isnan(score));
     ASSERT_TRUE(isnan(mae));
-    ASSERT_TRUE(neuralNetwork.hasNan());
-    
 }

--- a/tests/dataset_tests/Iris/IrisTest.cpp
+++ b/tests/dataset_tests/Iris/IrisTest.cpp
@@ -52,25 +52,3 @@ TEST_F(IrisTest, trainNeuralNetwork)
     auto accuracy = neuralNetwork.getGlobalClusteringRateMax();
     ASSERT_ACCURACY(accuracy, 0.98f);
 }
-
-TEST_F(IrisTest, correctlyNan)
-{
-    StraightforwardNeuralNetwork neuralNetwork({
-        Input(4),
-        FullyConnected(25),
-        FullyConnected(3)
-    },
-        StochasticGradientDescent(0.99f, 0.99f));
-    neuralNetwork.startTraining(*data);
-    neuralNetwork.waitFor(10_s);
-    neuralNetwork.stopTraining();
-    auto accuracy = neuralNetwork.getGlobalClusteringRate();
-    auto score = neuralNetwork.getF1Score();
-    auto mae = neuralNetwork.getMeanAbsoluteError();
-    cout << "  accuracy = " << accuracy << endl;
-    cout << "  mae = " << mae << endl;
-    ASSERT_TRUE(neuralNetwork.hasNan());
-    ASSERT_TRUE(isnan(accuracy));
-    ASSERT_TRUE(isnan(score));
-    ASSERT_TRUE(isnan(mae));
-}

--- a/tests/unit_tests/IdentityTests.cpp
+++ b/tests/unit_tests/IdentityTests.cpp
@@ -19,7 +19,7 @@ TEST(Identity, WorksWithSmallNumbers)
     neuralNetwork.waitFor(0.01_mae || 3_s);
     neuralNetwork.stopTraining();
 
-    float mae = neuralNetwork.getMeanAbsoluteError();
+    float mae = neuralNetwork.getMeanAbsoluteErrorMin();
 
     if (mae <= 0.01)
         ASSERT_SUCCESS();
@@ -47,7 +47,7 @@ TEST(Identity, WorksWithBigNumbers)
     neuralNetwork.waitFor(1.0_mae || 5_s);
     neuralNetwork.stopTraining();
 
-    float mae = neuralNetwork.getMeanAbsoluteError();
+    float mae = neuralNetwork.getMeanAbsoluteErrorMin();
 
     ASSERT_MAE(mae, 2);
 }
@@ -69,7 +69,7 @@ TEST(Identity, WorksWithLotsOfNumbers)
     neuralNetwork.stopTraining();
 
     float accuracy = neuralNetwork.getGlobalClusteringRateMax() * 100.0f;
-    float mae = neuralNetwork.getMeanAbsoluteError();
+    float mae = neuralNetwork.getMeanAbsoluteErrorMin();
 
     if (accuracy == 100
         && mae < precision

--- a/tests/unit_tests/IdentityTests.cpp
+++ b/tests/unit_tests/IdentityTests.cpp
@@ -68,7 +68,7 @@ TEST(Identity, WorksWithLotsOfNumbers)
     neuralNetwork.waitFor(1.00_acc || 3_s); // train neural network until 100% accurary or 3s on a parallel thread
     neuralNetwork.stopTraining();
 
-    float accuracy = neuralNetwork.getGlobalClusteringRate() * 100.0f;
+    float accuracy = neuralNetwork.getGlobalClusteringRateMax() * 100.0f;
     float mae = neuralNetwork.getMeanAbsoluteError();
 
     if (accuracy == 100

--- a/tests/unit_tests/NumericLimitTests.cpp
+++ b/tests/unit_tests/NumericLimitTests.cpp
@@ -60,17 +60,17 @@ protected:
     static void testNeuralNetwork(StraightforwardNeuralNetwork& nn)
     {
         nn.startTraining(*data);
-        nn.waitFor(10_s);
+        nn.waitFor(1_s);
         nn.stopTraining();
         auto mae = nn.getMeanAbsoluteError();
         auto acc = nn.getGlobalClusteringRate();
-        ASSERT_ACCURACY(acc, 1.0f);
-        ASSERT_MAE(mae, 0.01f);
+        ASSERT_ACCURACY(acc, 0.1f);
+        ASSERT_MAE(mae, 1.5f);
     }
 
     static void SetUpTestSuite()
     {
-        createData(5000, 100);
+        createData(1000, 50);
     }
 
     static unique_ptr<Data> data;
@@ -85,7 +85,7 @@ TEST_F(NumericLimitTests, WithSigmoid)
                                                    FullyConnected(5, activation::sigmoid),
                                                    FullyConnected(1, activation::sigmoid)
                                                },
-                                               StochasticGradientDescent(0.1f, 0.99f));
+                                               StochasticGradientDescent(0.9999f, 0.9999f));
     testNeuralNetwork(neuralNetwork);
 }
 
@@ -96,6 +96,6 @@ TEST_F(NumericLimitTests, WithTanh)
                                                    FullyConnected(5, activation::tanh),
                                                    FullyConnected(1, activation::tanh)
                                                },
-                                               StochasticGradientDescent(0.1f, 0.99f));
+                                               StochasticGradientDescent(0.9999f, 0.9999f));
     testNeuralNetwork(neuralNetwork);
 }

--- a/tests/unit_tests/NumericLimitTests.cpp
+++ b/tests/unit_tests/NumericLimitTests.cpp
@@ -1,0 +1,103 @@
+#include <cstddef>
+#include "../ExtendedGTest.hpp"
+#include "tools/Tools.hpp"
+#include "neural_network/StraightforwardNeuralNetwork.hpp"
+
+using namespace std;
+using namespace snn;
+
+unique_ptr<Data> createDataForNumericLimitTests(int sizeOfTraining, int sizeOfTesting, float output);
+void testNeuralNetworkForNumericLimitTests(StraightforwardNeuralNetwork& nn, Data& d);
+
+TEST(NumericLimit, AlwaysOneWithSigmoid)
+{
+    unique_ptr<Data> data = createDataForNumericLimitTests(5000, 100, 1.0f);
+    StraightforwardNeuralNetwork neuralNetwork({
+        Input(3),
+        FullyConnected(3, activation::sigmoid),
+        FullyConnected(1, activation::sigmoid)
+    });
+    testNeuralNetworkForNumericLimitTests(neuralNetwork, *data);
+}
+
+TEST(NumericLimit, AlwaysZeroWithSigmoid)
+{
+    unique_ptr<Data> data = createDataForNumericLimitTests(5000, 100, 0.0f);
+    StraightforwardNeuralNetwork neuralNetwork({
+        Input(3),
+        FullyConnected(3, activation::sigmoid),
+        FullyConnected(1, activation::sigmoid)
+    });
+    testNeuralNetworkForNumericLimitTests(neuralNetwork, *data);
+}
+
+TEST(NumericLimit, AlwaysOneWithTanh)
+{
+    unique_ptr<Data> data = createDataForNumericLimitTests(5000, 100, 1.0f);
+    StraightforwardNeuralNetwork neuralNetwork({
+        Input(3),
+        FullyConnected(3, activation::tanh),
+        FullyConnected(1, activation::tanh)
+    });
+    testNeuralNetworkForNumericLimitTests(neuralNetwork, *data);
+}
+
+TEST(NumericLimit, AlwaysZeroWithTanh)
+{
+    unique_ptr<Data> data = createDataForNumericLimitTests(5000, 100, 0.0f);
+    StraightforwardNeuralNetwork neuralNetwork({
+        Input(3),
+        FullyConnected(3, activation::tanh),
+        FullyConnected(1, activation::tanh)
+    });
+    testNeuralNetworkForNumericLimitTests(neuralNetwork, *data);
+}
+
+void testNeuralNetworkForNumericLimitTests(StraightforwardNeuralNetwork& nn, Data& d)
+{
+    nn.startTraining(d);
+    nn.waitFor(10_s);
+    nn.stopTraining();
+    auto mae = nn.getMeanAbsoluteError();
+    auto acc = nn.getGlobalClusteringRateMax();
+    ASSERT_ACCURACY(acc, 1.0f);
+    ASSERT_MAE(mae, 0.01f);
+}
+
+unique_ptr<Data> createDataForNumericLimitTests(int sizeOfTraining, int sizeOfTesting, float output)
+{
+    vector2D<float> trainingInputData;
+    vector2D<float> trainingExpectedOutputs;
+    trainingInputData.reserve(sizeOfTraining);
+    trainingExpectedOutputs.resize(sizeOfTraining, {output});
+
+    for (int i = 0; i < sizeOfTraining; ++i)
+    {
+        auto r1 = internal::Tools::randomBetween(0.0f, 1.0f);
+        auto r2 = internal::Tools::randomBetween(0.0f, 1.0f);
+        auto r3 = internal::Tools::randomBetween(0.0f, 1.0f);
+        trainingInputData.push_back({r1, r2, r3});
+    }
+
+    vector2D<float> testingInputData(sizeOfTesting);
+    std::generate(testingInputData.begin(), testingInputData.end(), [] { return vector<float>{0.0f}; });
+
+
+    vector2D<float> testingExpectedOutputs;
+    testingExpectedOutputs.resize(sizeOfTesting, {output});
+
+    for (int i = 0; i < sizeOfTesting; ++i)
+    {
+       auto r1 = internal::Tools::randomBetween(0.0f, 1.0f);
+        auto r2 = internal::Tools::randomBetween(0.0f, 1.0f);
+        auto r3 = internal::Tools::randomBetween(0.0f, 1.0f);
+        trainingInputData.push_back({r1, r2, r3});
+    }
+
+    auto data = make_unique<Data>(problem::regression,
+                                  trainingInputData,
+                                  trainingExpectedOutputs,
+                                  testingInputData,
+                                  testingExpectedOutputs);
+    return data;
+}


### PR DESCRIPTION
I will change this pull request, I will not stop training neural network when there is a NaN, i will just pevent the neural network to return any NaN value:
- [ ] Create math namespace and recode my own exp function
- [ ] Manage all special cases for the activation functions
- [ ] Add Unit test on activation function
- [x] Use tanh instead of exp to write sigmoid function