### PR TITLE
Use custom circular data instead of std::queue

### DIFF
--- a/src/neural_network/layer/neuron/CircularData.cpp
+++ b/src/neural_network/layer/neuron/CircularData.cpp
@@ -1,0 +1,42 @@
+#include "CircularData.hpp"
+
+#include <cassert>
+#include <utility>
+
+using namespace std;
+
+void snn::internal::CircularData::initialize(const size_t queueSize, const size_t dataSize)
+{
+    this->queue.clear();
+    this->queue.resize(queueSize);
+    for (auto& d : this->queue)
+        d = vector<float>(dataSize, 0.0f);
+}
+
+std::vector<float> snn::internal::CircularData::getBack()
+{
+    assert(this->indexGet <= this->queue.size());
+    if (this->indexGet >= this->queue.size())
+        this->indexGet = 0;
+    return this->queue[this->indexGet++];
+}
+
+void snn::internal::CircularData::pushBack(std::vector<float> data)
+{
+    assert(this->indexPush <= this->queue.size());
+    if (this->indexPush >= this->queue.size())
+        this->indexPush = 0;
+    this->queue[this->indexPush++] = std::move(data);
+}
+
+bool snn::internal::CircularData::operator==(const CircularData& other) const
+{
+    return this->queue == other.queue
+        && this->indexGet == other.indexGet
+        && this->indexPush == other.indexPush;
+}
+
+bool snn::internal::CircularData::operator!=(const CircularData& other) const
+{
+    return !(*this == other);
+}

--- a/src/neural_network/layer/neuron/CircularData.hpp
+++ b/src/neural_network/layer/neuron/CircularData.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <vector>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+
+namespace snn::internal
+{
+    class CircularData final
+    {
+    private:
+        friend class StochasticGradientDescent;
+        friend class boost::serialization::access;
+        template <class Archive>
+        void serialize(Archive& ar, unsigned version);
+
+        std::vector<std::vector<float>> queue;
+        size_t indexPush = 0;
+        size_t indexGet = 0;
+
+    public:
+        CircularData() = default; // use restricted to Boost library only
+        void initialize(size_t queueSize, size_t dataSize); // should be call after the ctor
+        ~CircularData() = default;
+
+        [[nodiscard]] std::vector<float> getBack();
+        void pushBack(std::vector<float> data);
+
+        bool operator==(const CircularData& other) const;
+        bool operator!=(const CircularData& other) const;
+    };
+
+    template <class Archive>
+    void CircularData::serialize(Archive& ar, [[maybe_unused]] const unsigned version)
+    {
+        ar & queue;
+        ar & indexGet;
+        ar & indexPush;
+    }
+}

--- a/src/neural_network/layer/neuron/Neuron.cpp
+++ b/src/neural_network/layer/neuron/Neuron.cpp
@@ -20,7 +20,8 @@ Neuron::Neuron(NeuronModel model, shared_ptr<NeuralNetworkOptimizer> optimizer)
         w = randomInitializeWeight(model.numberOfWeights);
     }
     this->bias = model.bias;
-    this->previousDeltaWeights.push(vector<float>(model.numberOfWeights, 0.0f));
+    this->lastInputs.initialize(this->batchSize, model.numberOfInputs);
+    this->previousDeltaWeights.initialize(this->batchSize, model.numberOfWeights);
 }
 
 float Neuron::randomInitializeWeight(int numberOfWeights)

--- a/src/neural_network/layer/neuron/Neuron.hpp
+++ b/src/neural_network/layer/neuron/Neuron.hpp
@@ -3,10 +3,9 @@
 #include <queue>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/vector.hpp>
-#include <boost/serialization/deque.hpp> // required to include queue.hpp
-#include <boost/serialization/queue.hpp>
 #include "BaseNeuron.hpp"
 #include "NeuronModel.hpp"
+#include "CircularData.hpp"
 #include "../../optimizer/StochasticGradientDescent.hpp"
 #include "activation_function/ActivationFunction.hpp"
 #include "../../../tools/Tools.hpp"
@@ -27,8 +26,8 @@ namespace snn::internal
         std::vector<float> weights;
         float bias;
 
-        std::queue<std::vector<float>> previousDeltaWeights;
-        std::queue<std::vector<float>> lastInputs;
+        CircularData previousDeltaWeights;
+        CircularData lastInputs;
         std::vector<float> errors;
 
         float sum = 0;

--- a/src/neural_network/optimizer/StochasticGradientDescent.cpp
+++ b/src/neural_network/optimizer/StochasticGradientDescent.cpp
@@ -42,7 +42,7 @@ void StochasticGradientDescent::updateWeights(SimpleNeuron& neuron, const float 
 #endif
 void StochasticGradientDescent::updateWeights(RecurrentNeuron& neuron, float error) const
 {
-    size_t w = 0;
+    int w = 0;
     const auto lr = this->learningRate / neuron.batchSize;
     const auto& m = this->momentum;
     const auto& numberOfInputs = neuron.numberOfInputs;

--- a/src/neural_network/optimizer/StochasticGradientDescent.cpp
+++ b/src/neural_network/optimizer/StochasticGradientDescent.cpp
@@ -21,11 +21,11 @@ shared_ptr<NeuralNetworkOptimizer> StochasticGradientDescent::clone() const
 
 void StochasticGradientDescent::updateWeights(SimpleNeuron& neuron, const float error) const
 {
-    const auto lr = this->learningRate / neuron.lastInputs.size(); // to activate the SIMD optimization
+    const auto lr = this->learningRate / neuron.batchSize; // to activate the SIMD optimization
     const auto& m = this->momentum;
     const auto& numberOfWeights = neuron.weights.size();
-    const auto& lastInputs = neuron.lastInputs.back();
-    const auto& previousDeltaWeights = neuron.previousDeltaWeights.back();
+    const auto& lastInputs = neuron.lastInputs.getBack();
+    const auto& previousDeltaWeights = neuron.previousDeltaWeights.getBack();
     vector<float> deltaWeights(numberOfWeights);
     #pragma omp simd
     for (size_t w = 0; w < numberOfWeights; ++w)
@@ -33,7 +33,7 @@ void StochasticGradientDescent::updateWeights(SimpleNeuron& neuron, const float 
         deltaWeights[w] = lr * error * lastInputs[w] + m * previousDeltaWeights[w];
         neuron.weights[w] += deltaWeights[w];
     }
-    neuron.previousDeltaWeights.push(deltaWeights);
+    neuron.previousDeltaWeights.pushBack(deltaWeights);
     neuron.bias += lr * error * neuron.bias;
 }
 
@@ -43,12 +43,12 @@ void StochasticGradientDescent::updateWeights(SimpleNeuron& neuron, const float 
 void StochasticGradientDescent::updateWeights(RecurrentNeuron& neuron, float error) const
 {
     size_t w = 0;
-    const auto lr = this->learningRate / neuron.lastInputs.size();
+    const auto lr = this->learningRate / neuron.batchSize;
     const auto& m = this->momentum;
-    const auto& numberOfInputs = neuron.lastInputs.back().size();
+    const auto& numberOfInputs = neuron.numberOfInputs;
     const auto& numberOfWeights = neuron.weights.size();
-    const auto& lastInputs = neuron.lastInputs.back();
-    const auto& previousDeltaWeights = neuron.previousDeltaWeights.back();
+    const auto& lastInputs = neuron.lastInputs.getBack();
+    const auto& previousDeltaWeights = neuron.previousDeltaWeights.getBack();
     vector<float> deltaWeights(numberOfWeights);
     #pragma omp simd // info C5002: Omp simd loop not vectorized due to reason '1305' (Not enough type information.)
     for (w = 0; w < numberOfInputs; ++w)
@@ -61,7 +61,7 @@ void StochasticGradientDescent::updateWeights(RecurrentNeuron& neuron, float err
 
     deltaWeights[w] = lr * neuron.recurrentError * neuron.previousOutput + m * previousDeltaWeights[w];
     neuron.weights[w] += deltaWeights[w];
-    neuron.previousDeltaWeights.push(deltaWeights);
+    neuron.previousDeltaWeights.pushBack(deltaWeights);
     #ifdef _MSC_VER
     #pragma warning(default:4701)
     #endif

--- a/tests/dataset_tests/Fashion-MNIST/FashionMnistTest.cpp
+++ b/tests/dataset_tests/Fashion-MNIST/FashionMnistTest.cpp
@@ -58,10 +58,10 @@ TEST_F(FashionMnistTest, convolutionNeuralNetwork)
         Convolution(1,3, activation::ReLU),
         FullyConnected(10)
         },
-        StochasticGradientDescent(0.01f, 0.0f));
-    neuralNetwork.train(*data, 1_ep || 20_s);
+        StochasticGradientDescent(0.001f, 0.8f));
+    neuralNetwork.train(*data, 10_ep || 200_s);
     auto accuracy = neuralNetwork.getGlobalClusteringRate();
-    ASSERT_ACCURACY(accuracy, 0.74);
+    ASSERT_ACCURACY(accuracy, 0.74f);
 }
 
 TEST_F(FashionMnistTest, DISABLED_trainBestNeuralNetwork)

--- a/tests/unit_tests/ArchitectureTests.cpp
+++ b/tests/unit_tests/ArchitectureTests.cpp
@@ -27,7 +27,7 @@ TEST(Architecture, ValidArchitectures)
     }
 }
 
-TEST(Architecture, invalidArchitectures)
+TEST(Architecture, InvalidArchitectures)
 {
     vector2D<LayerModel> Architectures =
     {

--- a/tests/unit_tests/ConvolutionTests.cpp
+++ b/tests/unit_tests/ConvolutionTests.cpp
@@ -90,6 +90,38 @@ TEST(Convolution, LayerConvolution2D)
     ASSERT_EQ(backOutput, expectedBackOutput);
 }
 
+TEST(Convolution, Momentum)
+{
+    vector<float> input {1.0f, 2.0f, 3.0f, 4.0f};
+
+    LayerModel model{
+        convolution,
+        4,
+        1,
+        4,
+        {1, 4, 1, 1.0f, activation::identity},
+        1,
+        4,
+        4,
+        1,
+        {1, 2, 2},
+        {}
+    };
+    auto sgd = std::make_shared<internal::StochasticGradientDescent>(0.1f, 0.9f);
+    internal::Convolution2D conv(model, sgd);
+    static_cast<internal::SimpleNeuron*>(conv.getNeuron(0))->setWeights({1.0f});
+  
+
+    for (auto i = 0; i < 3; ++i)
+    {
+        vector<float> error {1.0f, 2.0f, 3.0f, 4.0f};
+        auto output = conv.output(input, false);
+        auto backOutput = conv.backOutput(error);
+        ASSERT_GT(output.size(), 0);
+        ASSERT_GT(backOutput.size(), 0);
+    }
+}
+
 TEST(Convolution, SimpleConvolution1D)
 {
     auto data = createDataForConvolutionTests();

--- a/tests/unit_tests/OptimizerTests.cpp
+++ b/tests/unit_tests/OptimizerTests.cpp
@@ -15,7 +15,7 @@ TEST(Optimizer, FindRightValueIn20)
         FullyConnected(6, activation::tanh),
         FullyConnected(1, activation::sigmoid)
     },
-        StochasticGradientDescent(0.02f, 0.5f));
+        StochasticGradientDescent(0.03f, 0.9f));
 
     neuralNetwork.train(*data, 1.00_acc || 2_s);
     auto mae = neuralNetwork.getMeanAbsoluteError();

--- a/tests/unit_tests/RecurrenceTests.cpp
+++ b/tests/unit_tests/RecurrenceTests.cpp
@@ -38,7 +38,7 @@ TEST(Recurrence, RepeatLastInput)
         FullyConnected(8),
         FullyConnected(1, activation::tanh)
     },
-        StochasticGradientDescent(0.02f));
+        StochasticGradientDescent(0.02f, 0.5f));
     testNeuralNetworkForRecurrence(neuralNetwork, *data);
 }
 
@@ -57,7 +57,7 @@ TEST(Recurrence, RepeatLastLastInput)
         GruLayer(8),
         FullyConnected(1)
     },
-        StochasticGradientDescent(0.04f, 0.9f));
+        StochasticGradientDescent(0.1f, 0.9f));
 
     testNeuralNetworkForRecurrence(neuralNetwork, *data);
 }
@@ -65,7 +65,7 @@ TEST(Recurrence, RepeatLastLastInput)
 inline
 void testNeuralNetworkForRecurrence(StraightforwardNeuralNetwork& nn, Data& d)
 {
-    nn.train(d, 1.0_acc || 4_s, 1, 50);
+    nn.train(d, 1.0_acc || 4_s, 1, 10);
     auto mae = nn.getMeanAbsoluteError();
     auto acc = nn.getGlobalClusteringRate();
     ASSERT_ACCURACY(acc, 1.0);


### PR DESCRIPTION
This change greatly improves the training time, and I also corrected a bug in the SGD momentum calculation.
⚠️ The tests on best neural networks are still disabled.