### PR TITLE
test(cifar): improve training

### DIFF
--- a/tests/manual_tests/Cifar10SimpleNetwork.py
+++ b/tests/manual_tests/Cifar10SimpleNetwork.py
@@ -3,10 +3,12 @@ import tensorflow as tf
 from tensorflow.keras import datasets, layers, models, optimizers
 import matplotlib.pyplot as plt
 
-(train_images, train_labels), (test_images,
-                               test_labels) = datasets.cifar10.load_data()
+(train_images, train_labels), (test_images, test_labels) = datasets.cifar10.load_data()
 # Normalize pixel values to be between 0 and 1
 train_images, test_images = train_images / 255.0, test_images / 255.0
+# Encode labels
+one_hot_train_labels = tf.one_hot(train_labels, 10)
+one_hot_test_labels = tf.one_hot(test_labels, 10)
 
 model = models.Sequential()
 model.add(layers.Input(shape=(32, 32, 3)))
@@ -22,13 +24,12 @@ model.add(layers.Dense(10))
 
 model.summary()
 
-model.compile(optimizer=optimizers.SGD(learning_rate=0.002, momentum=0.9),
-              loss=tf.keras.losses.SparseCategoricalCrossentropy(
-                  from_logits=True),
+model.compile(optimizer=optimizers.SGD(learning_rate=0.001 * 10, momentum=0.0),
+              loss=tf.keras.losses.MeanSquaredError(),
               metrics=['accuracy'])
 
-history = model.fit(train_images, train_labels, epochs=20,  # batch_size=1
-                    validation_data=(test_images, test_labels))
+history = model.fit(train_images, one_hot_train_labels, epochs=20, batch_size=1,
+                    validation_data=(test_images, one_hot_test_labels))
 
 plt.plot(history.history['accuracy'], label='accuracy')
 plt.plot(history.history['val_accuracy'], label='val_accuracy')


### PR DESCRIPTION
Updates hyperparameters to become more like an SNN.

Logs
```
50000/50000 [==============================] - 106s 2ms/step - loss: 0.0831 - accuracy: 0.2910 - val_loss: 0.0776 - val_accuracy: 0.3749
Epoch 2/20
50000/50000 [==============================] - 102s 2ms/step - loss: 0.0757 - accuracy: 0.4274 - val_loss: 0.0734 - val_accuracy: 0.4673
Epoch 3/20
50000/50000 [==============================] - 109s 2ms/step - loss: 0.0715 - accuracy: 0.4896 - val_loss: 0.0705 - val_accuracy: 0.5005
Epoch 4/20
50000/50000 [==============================] - 138s 3ms/step - loss: 0.0684 - accuracy: 0.5224 - val_loss: 0.0687 - val_accuracy: 0.5104
Epoch 5/20
50000/50000 [==============================] - 156s 3ms/step - loss: 0.0658 - accuracy: 0.5499 - val_loss: 0.0646 - val_accuracy: 0.5677
Epoch 6/20
50000/50000 [==============================] - 156s 3ms/step - loss: 0.0632 - accuracy: 0.5735 - val_loss: 0.0625 - val_accuracy: 0.5657
Epoch 7/20
50000/50000 [==============================] - 150s 3ms/step - loss: 0.0608 - accuracy: 0.5911 - val_loss: 0.0597 - val_accuracy: 0.5985
Epoch 8/20
50000/50000 [==============================] - 132s 3ms/step - loss: 0.0586 - accuracy: 0.6064 - val_loss: 0.0591 - val_accuracy: 0.5950
Epoch 9/20
50000/50000 [==============================] - 146s 3ms/step - loss: 0.0567 - accuracy: 0.6221 - val_loss: 0.0571 - val_accuracy: 0.6123
Epoch 10/20
50000/50000 [==============================] - 164s 3ms/step - loss: 0.0549 - accuracy: 0.6333 - val_loss: 0.0556 - val_accuracy: 0.6252
Epoch 11/20
50000/50000 [==============================] - 151s 3ms/step - loss: 0.0534 - accuracy: 0.6414 - val_loss: 0.0544 - val_accuracy: 0.6303
Epoch 12/20
50000/50000 [==============================] - 131s 3ms/step - loss: 0.0519 - accuracy: 0.6522 - val_loss: 0.0541 - val_accuracy: 0.6341
Epoch 13/20
50000/50000 [==============================] - 142s 3ms/step - loss: 0.0507 - accuracy: 0.6618 - val_loss: 0.0533 - val_accuracy: 0.6382
Epoch 14/20
50000/50000 [==============================] - 152s 3ms/step - loss: 0.0495 - accuracy: 0.6738 - val_loss: 0.0513 - val_accuracy: 0.6556
Epoch 15/20
50000/50000 [==============================] - 148s 3ms/step - loss: 0.0484 - accuracy: 0.6825 - val_loss: 0.0504 - val_accuracy: 0.6593
Epoch 16/20
50000/50000 [==============================] - 127s 3ms/step - loss: 0.0474 - accuracy: 0.6877 - val_loss: 0.0499 - val_accuracy: 0.6664
Epoch 17/20
50000/50000 [==============================] - 133s 3ms/step - loss: 0.0463 - accuracy: 0.6966 - val_loss: 0.0491 - val_accuracy: 0.6733
Epoch 18/20
50000/50000 [==============================] - 150s 3ms/step - loss: 0.0454 - accuracy: 0.7045 - val_loss: 0.0495 - val_accuracy: 0.6681
Epoch 19/20
50000/50000 [==============================] - 150s 3ms/step - loss: 0.0445 - accuracy: 0.7121 - val_loss: 0.0482 - val_accuracy: 0.6773
Epoch 20/20
50000/50000 [==============================] - 153s 3ms/step - loss: 0.0437 - accuracy: 0.7194 - val_loss: 0.0481 - val_accuracy: 0.6776
313/313 - 2s - loss: 27.6489 - accuracy: 0.1218 - 2s/epoch - 6ms/step
0.121799997985363
```